### PR TITLE
Fixed undefined reference

### DIFF
--- a/src/explicit_finite_aut.cc
+++ b/src/explicit_finite_aut.cc
@@ -324,6 +324,13 @@ ExplicitFiniteAut ExplicitFiniteAut::Intersection(
 }
 
 bool ExplicitFiniteAut::CheckInclusion(
+    const ExplicitFiniteAut&    smaller,
+    const ExplicitFiniteAut&    bigger) {
+    return ExplicitFiniteAut::CheckInclusion(smaller, bigger, InclParam());
+}
+
+
+bool ExplicitFiniteAut::CheckInclusion(
 	const ExplicitFiniteAut&    smaller,
 	const ExplicitFiniteAut&    bigger,
 	const InclParam&						params)


### PR DESCRIPTION
Was getting an undefined reference here, probably just forgotten.

Side note: Is there a clean way to define epsilon transitions? 